### PR TITLE
Set AWS_DEFAULT_REGION environment variable for R User

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -9,5 +9,6 @@ useradd -g $GROUP -u $USER_UID -d /home/$USER $USER
 echo "auth-proxy-sign-in-url=https://${USER}.rstudio.users.analytics.kops.integration.dsd.io/login" >> /etc/rstudio/rserver.conf
 echo "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}" >> /usr/local/lib/R/etc/Renviron
 echo "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}" >> /usr/local/lib/R/etc/Renviron
+echo "AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION}" >> /usr/local/lib/R/etc/Renviron
 
 /usr/lib/rstudio-server/bin/rserver --server-daemonize 0


### PR DESCRIPTION
This copy this environment variable for the user (needed by cloudyr and
other AWS libraries) from the root environment variable value.