### PR TITLE
Installing texlive-latex-extra package required for PDF generation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ RUN apt-get update \
   && git config --system push.default simple
 
 # TeX Distribution: Used for PDF generation
-RUN apt-get install -y texinfo texlive
+RUN apt-get install -y texinfo texlive texlive-latex-extra
 
 # APT Cleanup
 RUN apt-get clean && rm -rf /var/lib/apt/lists/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # analytics-platform-rstudio
+
 RStudio Docker image for Analytics Platform
+
+
+## Tricks
+
+### Find apt package with a certain file
+
+RStudio may complain about some missing file. There is a command to find
+the package containing the file:
+
+```bash
+$ apt-get install apt-file
+$ apt-file update
+$ apt-file search titling.sty
+```
+
+See: https://github.com/rstudio/rmarkdown/issues/359#issuecomment-253335365


### PR DESCRIPTION
When trying to generate a PDF in RStudio I got the following error:

    LaTeX Error: File `titling.sty' not found

Thanks to apt-file (See README) I managed to pinpoint the exact package
providing it.

**NOTE**: There is a TeX package which install pretty much everything but it's
big (~2GB?) and I would avoid to install it unless necessary.