### PR TITLE
Include dependency on libpng and tidyverse package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,7 @@ RUN apt-get update \
     libpcre3-dev \
     liblzma-dev \
     libicu-dev \
+    libpng-dev \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/
 
@@ -108,7 +109,8 @@ RUN R -e "install.packages(c(\
     'rprojroot', \
     'rmarkdown', \
     'readr', \
-    'shiny' \
+    'shiny', \
+    'tidyverse' \
     ))" \
 
   # Install R S3 package


### PR DESCRIPTION
Minor additions to dependencies to resolve:

Shiny server requires libpng, but this is not in our R Studio (see [here](https://github.com/rstudio/shiny-server/wiki/Building-Shiny-Server-from-Source))

The Data Science team is recommending the use of Tidyverse packages as sensible defaults, so it makes sense for this to be installed by default on the platform.