### PR TITLE
Added jpeg, pdftools, and geospatial dependencies 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ RUN apt-get update \
     libicu-dev \
     libpng-dev \
     libjpeg-dev \
+    libpoppler-cpp-dev \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/ \
   \

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,9 @@ RUN apt-get update \
     libpng-dev \
     libjpeg-dev \
     libpoppler-cpp-dev \
+    libgeos-dev \
+    libgdal1-dev \
+    libproj-dev \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/ \
   \

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ RUN apt-get update \
     liblzma-dev \
     libicu-dev \
     libpng-dev \
+    libjpeg-dev \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/ \
   \


### PR DESCRIPTION
Dependencies added from survey of R users local packages. I've also added the common dependencies used by spatial R packages. 

One exception is the `sf` package that requires version >2 of gdal, which isn't in the ubuntu default rep. Can be added here `sudo add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable` but not part of this pull request. 