### PR TITLE
Removes dependency on upstream Docker image from rocker/rstudio

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -184,6 +184,8 @@ RUN R -e "install.packages(c(\
 RUN git config --system credential.helper 'cache --timeout=3600' \
   && git config --system push.default simple
 
+RUN echo "rstudio:rstudio" | chpasswd
+
 COPY start.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/start.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,68 @@
-FROM rocker/r-ver:3.4.0
+FROM debian:stretch
 
 ENV USER=rstudio
-# ENV USER_NAMESPACE
 
 ARG PANDOC_TEMPLATES_VERSION
+ARG BUILD_DATE
 ENV PANDOC_TEMPLATES_VERSION ${PANDOC_TEMPLATES_VERSION:-1.18}
+ENV TERM=xterm \
+    DEBIAN_FRONTEND=noninteractive \
+    PATH=/usr/lib/rstudio-server/bin:$PATH
 
-## Add RStudio binaries to PATH
-ENV PATH /usr/lib/rstudio-server/bin:$PATH
+# Set locale
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends locales \
+  && echo "en_GB.UTF-8 UTF-8" >> /etc/locale.gen \
+  && locale-gen en_GB.utf8 \
+  && /usr/sbin/update-locale LANG=en_GB.UTF-8 \
+  && rm -rf /var/lib/apt/lists/*
+ENV LC_ALL=en_GB.UTF-8 \
+    LANG=en_GB.UTF-8
+
+# Install R Dependencies
+RUN apt-get update \
+  && apt-get install -y software-properties-common apt-transport-https gnupg \
+  && add-apt-repository 'deb https://cran.ma.imperial.ac.uk/bin/linux/debian stretch-cran34/' \
+  && apt-key adv --recv-key 'E19F5F87128899B192B1A2C2AD5F960A256A04AF' \
+  && apt-get update \
+  && apt-get install -y \
+    r-base \
+    r-base-dev \
+    r-recommended \
+    libopenblas-base \
+    curl \
+    wget
+
+  ## Add a default CRAN mirror
+RUN echo "options(repos = c(CRAN = 'https://cran.rstudio.com/'), download.file.method = 'libcurl')" >> /etc/R/Rprofile.site \
+  ## Add a library directory (for user-installed packages)
+  && mkdir -p /usr/local/lib/R/site-library \
+  && chown root:staff /usr/local/lib/R/site-library \
+  && chmod g+wx /usr/local/lib/R/site-library \
+  ## Fix library path
+  && echo "R_LIBS_USER='/usr/local/lib/R/site-library'" >> /etc/R/Renviron \
+  && echo "R_LIBS=\${R_LIBS-'/usr/local/lib/R/site-library:/usr/local/lib/R/library:/usr/lib/R/library'}" >> /etc/R/Renviron \
+  ## install packages from date-locked MRAN snapshot of CRAN
+  && [ -z "$BUILD_DATE" ] && BUILD_DATE=$(TZ="America/Los_Angeles" date -I) || true \
+  && MRAN=https://mran.microsoft.com/snapshot/${BUILD_DATE} \
+  && echo MRAN=$MRAN >> /etc/environment \
+  && export MRAN=$MRAN \
+  ## MRAN becomes default only in versioned images
+  ## Use littler installation scripts
+  && Rscript -e "install.packages(c('littler', 'docopt'), repo = '$MRAN')" \
+  && ln -s /usr/local/lib/R/site-library/littler/examples/install2.r /usr/local/bin/install2.r \
+  && ln -s /usr/local/lib/R/site-library/littler/examples/installGithub.r /usr/local/bin/installGithub.r \
+  && ln -s /usr/local/lib/R/site-library/littler/bin/r /usr/local/bin/r \
+  ## TEMPORARY WORKAROUND to get more robust error handling for install2.r prior to littler update
+  && curl -O /usr/local/bin/install2.r https://github.com/eddelbuettel/littler/raw/master/inst/examples/install2.r \
+  && chmod +x /usr/local/bin/install2.r \
+  && rm -rf /var/lib/apt/lists/*
 
 ## Download and install RStudio server & dependencies
 ## Attempts to get detect latest version, otherwise falls back to version given in $VER
 ## Symlink pandoc, pandoc-citeproc so they are available system-wide
-ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
-    file \
     git \
     libapparmor1 \
     libcurl4-openssl-dev \
@@ -25,7 +72,6 @@ RUN apt-get update \
     psmisc \
     python-setuptools \
     sudo \
-    wget \
     rrdtool \
     openssh-client \
     libxml2-dev \
@@ -43,11 +89,9 @@ RUN apt-get update \
     libjpeg-dev \
     libpoppler-cpp-dev \
     libgeos-dev \
-    libgdal1-dev \
+    libgdal-dev \
     libproj-dev \
-  && apt-get clean \
-  && rm -rf /var/lib/apt/lists/ \
-  \
+  && rm -rf /var/lib/apt/lists/* \
   && wget -O libssl1.0.0.deb http://ftp.debian.org/debian/pool/main/o/openssl/libssl1.0.0_1.0.1t-1+deb8u6_amd64.deb \
   && dpkg -i libssl1.0.0.deb \
   && rm libssl1.0.0.deb
@@ -82,8 +126,8 @@ RUN wget -q https://download2.rstudio.org/rstudio-server-pro-1.0.143-amd64.deb \
     \n# where this Docker container is running. \
     \nif(is.na(Sys.getenv("HTTR_LOCALHOST", unset=NA))) { \
     \n  options(httr_oob_default = TRUE) \
-    \n}' >> /usr/local/lib/R/etc/Rprofile.site \
-  && echo "PATH=\"${PATH}\"" >> /usr/local/lib/R/etc/Renviron \
+    \n}' >> /etc/R/Rprofile.site \
+  && echo "PATH=\"${PATH}\"" >> /etc/R/Renviron \
   && echo "r-libs-user=~/R/library" >> /etc/rstudio/rsession.conf \
 
   ## Configure RStudio profile

--- a/start.sh
+++ b/start.sh
@@ -7,9 +7,9 @@ USER_UID=1001
 useradd -g $GROUP -u $USER_UID -d /home/$USER $USER
 
 echo "auth-proxy-sign-in-url=https://${USER}-rstudio.${TOOLS_DOMAIN}/logout" >> /etc/rstudio/rserver.conf
-echo "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}" >> /usr/local/lib/R/etc/Renviron
-echo "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}" >> /usr/local/lib/R/etc/Renviron
-echo "AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION}" >> /usr/local/lib/R/etc/Renviron
+echo "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}" >> /etc/R/Renviron
+echo "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}" >> /etc/R/Renviron
+echo "AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION}" >> /etc/R/Renviron
 
 /usr/lib/rstudio-server/bin/rserver --server-daemonize 0
 


### PR DESCRIPTION
Currently we build our own Docker image on top of a [public base image](https://hub.docker.com/r/rocker/rstudio/) - unfortunately the maintainers of this public image frequently push updates to existing tags, causing unpredictable build failures in our image.

To address this, this PR removes the dependency on the upstream public image, and installs RStudio in a base Debian Stretch image.

To test:

Use our 'control panel' jenkins to deploy this image for yourself - the docker tag value is `vendored-dockerfile`. Once your RStudio instance is deployed, verify that both existing and new R sessions work as intended, have packages such as `tidyverse` and `codetools` preinstalled, and that new packages via `install.packages` are installed into your `~/R/library` directory.

**Note:** existing R sessions may complain about locale environment variables when attempting to install packages - restarting the R session via the `Session > Restart R` menu options will resolve the issue.