### PR TITLE
Do not use MOJ fork of aws.signature library

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,6 @@ RUN wget -q https://download2.rstudio.org/rstudio-server-pro-1.0.143-amd64.deb \
   \nserver-access-log=1 \
   \nserver-project-sharing=0 \
   \nserver-health-check-enabled=1 \
-  \nauth-proxy=1 \
   \n' >> /etc/rstudio/rserver.conf \
 
   # Install pandoc
@@ -96,6 +95,7 @@ RUN wget -q https://download2.rstudio.org/rstudio-server-pro-1.0.143-amd64.deb \
 RUN R -e "install.packages(c(\
     'Rcpp', \
     'aws.s3', \
+    'aws.signature', \
     'base64enc', \
     'base64enc', \
     'bitops', \
@@ -124,7 +124,7 @@ RUN R -e "install.packages(c(\
     ))" \
 
   # Install R S3 package
-  && R -e "install.packages(c('aws.s3'), \
+  && R -e "install.packages(c('aws.signature', 'aws.s3'), \
     repos = c('cloudyr' = 'http://cloudyr.github.io/drat'))" \
 
   # Install MOJ S3tools package

--- a/start.sh
+++ b/start.sh
@@ -6,7 +6,11 @@ USER_UID=1001
 
 useradd -g $GROUP -u $USER_UID -d /home/$USER $USER
 
-echo "auth-proxy-sign-in-url=https://${USER}-rstudio.${TOOLS_DOMAIN}/logout" >> /etc/rstudio/rserver.conf
+if [ -z "$NO_AUTH_PROXY" ]; then
+    echo "auth-proxy=1" >> /etc/rstudio/rserver.conf
+    echo "auth-proxy-sign-in-url=https://${USER}-rstudio.${TOOLS_DOMAIN}/logout" >> /etc/rstudio/rserver.conf
+fi
+
 echo "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}" >> /usr/local/lib/R/etc/Renviron
 echo "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}" >> /usr/local/lib/R/etc/Renviron
 echo "AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION}" >> /usr/local/lib/R/etc/Renviron


### PR DESCRIPTION
Also, add environment variable `NO_AUTH_PROXY`, which if given a value will allow running the docker container without an authentication reverse proxy - this is useful to run Rstudio on your own machine instead of in the cloud. **NB:** You have to set the `rstudio` user password in the container.