### PR TITLE
add dependency for ReporteRs package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,6 +94,7 @@ RUN apt-get update \
     libgeos-dev \
     libgdal-dev \
     libproj-dev \
+    libcairo2-dev \
   && rm -rf /var/lib/apt/lists/* \
   && wget -O libssl1.0.0.deb http://ftp.debian.org/debian/pool/main/o/openssl/libssl1.0.0_1.0.1t-1+deb8u6_amd64.deb \
   && dpkg -i libssl1.0.0.deb \


### PR DESCRIPTION
amythomas is trying to `install.packages("ReporteRs")` on the platform but it is failing on missing dependency. 

This PR adds it. 

```
** package ‘gdtools’ successfully unpacked and MD5 sums checked
Package cairo was not found in the pkg-config search path.
Perhaps you should add the directory containing `cairo.pc'
to the PKG_CONFIG_PATH environment variable
No package 'cairo' found
Using PKG_CFLAGS=
Using PKG_LIBS=-lcairo
------------------------- ANTICONF ERROR ---------------------------
Configuration failed because cairo was not found. Try installing:
 * deb: libcairo2-dev (Debian, Ubuntu)
 * rpm: cairo-devel (Fedora, CentOS, RHEL)
 * csw: libcairo_dev (Solaris)
 * brew: cairo (OSX)
If cairo is already installed, check that 'pkg-config' is in your
PATH and PKG_CONFIG_PATH contains a cairo.pc file. If pkg-config
is unavailable you can set INCLUDE_DIR and LIB_DIR manually via:
R CMD INSTALL --configure-vars='INCLUDE_DIR=... LIB_DIR=...'
--------------------------------------------------------------------
```