### PR TITLE
Set secure cookie key from env var to enable bypassing authentication

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -ex
+set -e
 
 GROUP=staff
 USER_UID=1001
@@ -7,14 +7,17 @@ USER_UID=1001
 if [ "$(id -u "$USER" 2>/dev/null)" != $USER_UID ]; then
     useradd -g $GROUP -u $USER_UID -d /home/$USER $USER
 fi
+
+# this is only for running locally - in-cluster, home directories are
+# provided via NAS
 echo "${USER}:${USER}" | chpasswd
 if [ ! -d /home/$USER ]; then
     mkdir -p /home/$USER
 fi
 chown "${USER}:${GROUP}" /home/$USER
 
-echo "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}" >> /etc/R/Renviron
-echo "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}" >> /etc/R/Renviron
-echo "AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION}" >> /etc/R/Renviron
+# set secure cookie key
+ echo -n "${SECURE_COOKIE_KEY}" > /var/lib/rstudio-server/secure-cookie-key
+chmod 600 /var/lib/rstudio-server/secure-cookie-key
 
-/usr/lib/rstudio-server/bin/rserver --server-daemonize 0
+/usr/lib/rstudio-server/bin/rserver --server-daemonize=0

--- a/start.sh
+++ b/start.sh
@@ -15,9 +15,10 @@ if [ ! -d /home/$USER ]; then
     mkdir -p /home/$USER
 fi
 chown "${USER}:${GROUP}" /home/$USER
+export HOME=/home/$USER
 
 # set secure cookie key
- echo -n "${SECURE_COOKIE_KEY}" > /var/lib/rstudio-server/secure-cookie-key
+echo -n "${SECURE_COOKIE_KEY}" > /var/lib/rstudio-server/secure-cookie-key
 chmod 600 /var/lib/rstudio-server/secure-cookie-key
 
 /usr/lib/rstudio-server/bin/rserver --server-daemonize=0


### PR DESCRIPTION
* Overwrite the default secure cookie key with one from an environment variable, so that we know it for encrypting the auth cookie in the proxy
* Don't echo commands, to avoid the key being logged