### PR TITLE
Disable RStudio authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,17 @@ RStudio Docker image for Analytics Platform
 
 [![Docker Repository on Quay](https://quay.io/repository/mojanalytics/rstudio/status "Docker Repository on Quay")](https://quay.io/repository/mojanalytics/rstudio)
 
+**IMPORTANT**: RStudio Server **authentication is disabled**.
+Do not run this image on the internet unless you secure it properly
+with an Auth Proxy in front of it.
+As authentication is disabled, RStudio Server needs to know which
+user is accessing RStudio, so you need to set the `USER` environment
+variable.
+
+
 ## Usage
 
-To add/remove R packages to this image? Edit the `R_packages` file accordingly then build the image remembering to 
+To add/remove R packages to this image? Edit the `R_packages` file accordingly then build the image remembering to
 update the tag
 
 #### Build
@@ -14,7 +22,7 @@ update the tag
 docker image build --no-cache -t quay.io/mojanalytics/rstudio .
 ```
 
-#### Run locally 
+#### Run locally
 ```
 docker container run -d --rm -p 8787:8787 quay.io/mojanalytics/rstudio
 ```
@@ -27,7 +35,7 @@ Tag
 docker image tag quay.io/mojanalytics/rstudio quay.io/mojanalytics/rstudio:<x.x.x>
 ```
 
-Push 
+Push
 ```
 docker image push quay.io/mojanalytics/rstudio:<x.x.x>
 ```

--- a/start.sh
+++ b/start.sh
@@ -78,6 +78,9 @@ export R_HOME=$CONDA_PREFIX/lib/R
   && touch "$R_HOME/etc/Renviron" \
   && chown "$USER" "$R_HOME/etc/Renviron"
 
+grep -q -F "USER" "$R_HOME/etc/Renviron" \
+  && sed -i "s|USER=.*|USER=\"${USER}\"|" "$R_HOME/etc/Renviron" \
+  || echo "USER=\"${USER}\"" >> "$R_HOME/etc/Renviron"
 
 grep -q -F "PATH" "$R_HOME/etc/Renviron" \
   && sed -i "s|PATH=.*|PATH=\"${PATH}\"|" "$R_HOME/etc/Renviron" \
@@ -95,7 +98,8 @@ grep -q -F "PKG_CONFIG_PATH" "$R_HOME/etc/Renviron" \
 sudo -i -u "${USER}" /usr/lib/rstudio-server/bin/rserver \
   --server-daemonize=0 \
   --rsession-ld-library-path="/usr/lib/rstudio-server:/opt/conda/lib:$RSTUDIO_ENV_PATH/lib" \
-  --rsession-which-r="$RSTUDIO_ENV_PATH/bin/R"
+  --rsession-which-r="$RSTUDIO_ENV_PATH/bin/R" \
+  --auth-none=1
 }
 function main() {
   init_user


### PR DESCRIPTION
**IMPORTANT**: This will start the server without authentication. Always
run this image behind an Auth Proxy (we do).

Why?
----
Currently we have to do [weird things] in a custom [rstudio-auth-proxy] in order to authenticate the user through RStudio Server.

The reason for disabling authentication is because this way we can
replace the custom [rstudio-auth-proxy] with the our generic [auth-proxy].
This will remove the need to manage two Auth Proxies which are doing
essentially the same thing.

Ticket
------

https://trello.com/c/5twZHrb4/215-try-to-replace-custom-rstudio-auth-proxy-with-our-usual-generic-one

[weird things]: https://github.com/ministryofjustice/analytics-platform-rstudio-auth-proxy/blob/8d4afb4982fddf3ad0d4446cca1e9f8455e160fe/app/auth.js
[rstudio-auth-proxy]: https://github.com/ministryofjustice/analytics-platform-rstudio-auth-proxy
[auth-proxy]: https://github.com/ministryofjustice/analytics-platform-auth-proxy