### PR TITLE
Bumping base image which contains new RStudio 1.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
-FROM rocker/verse:3.5.1@sha256:3ab705fd5ef8970f19ba7ca256f1cd158c6d7514cd39f33ab3b8cde3ada42bbd
+FROM rocker/verse:3.5.3@sha256:7cf4253239c338fbef924ddf46b7632cc52d1da7616e3d80b11bca0093071cb2
 LABEL maintainer=analytics-platform-tech@digital.justice.gov.uk
 
 ARG GITHUB_PAT
 ARG NCPUS=1
 
-ENV R_VERSION=${R_VERSION:-3.5.1}
+# R version 3.5.3 is not available via Conda, sticking to 3.5.1
+# ENV R_VERSION=${R_VERSION:-3.5.1}
+ENV R_VERSION=3.5.1
 ENV PY_VERSION=${PY_VERSION:-3.7}
 
 ENV USER=rstudio


### PR DESCRIPTION
Previous test highlighted the fact that running shiny apps through RStudio didn't work.
When I tried again recently I could't reproduce this anymore. One theory is that the switch to the `auth-proxy` solved the problem somehow (we previously used `rstudio-auth-proxy`).

Release notes: https://blog.rstudio.com/2019/04/30/rstudio-1-2-release/
Ticket: https://trello.com/c/MVpNikT8/248-give-rstudio-12-image-another-try
Old ticket: https://trello.com/c/rguKYALc/214-try-to-upgrade-rstudio-docker-image-to-use-latest-version