### PR TITLE
add nbstripout pkg with pip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.0.1] - 2020-03-19
+### Changed
+- Added pip install nbstripout to filter '.ipynb' files on git commit
+
 ## [2.0.0] - 2018-04-24
 ### Changed
 - R version 3.4.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -80,7 +80,8 @@ RUN ln -s /bin/tar /bin/gtar \
     && chmod a+rx /usr/bin/phantomjs
 
 RUN npm config set unsafe-perm true \
-    && npm install -g vega vega-lite
+    && npm install -g vega vega-lite \ 
+    && pip install --upgrade nbstripout
 
 # We want all packages to use the default MRAN mirror so that when we upgrade users, they don't magically get new packages
 # However, when they install their own packages, we want this to come from latest CRAN


### PR DESCRIPTION
We need to install nbstripout on R Studio, so if user decided to git commit his file in r studio server we run nbstripout on ".ipynb" files.

Already tested it on my branch on quay build