### PR TITLE
Add nbstripout pkg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ENV USER=rstudio
 ENV LC_ALL=en_GB.UTF-8 \
     LANG=en_GB.UTF-8
 
-ENV PATH /opt/conda/bin:$HOME/.local/bin:$PATH
+ENV PATH /opt/conda/bin:$PATH
 
 ## Set locale & install packages
 RUN echo "en_GB.UTF-8 UTF-8" >> /etc/locale.gen \
@@ -107,3 +107,5 @@ RUN chmod +x /usr/local/bin/start.sh
 EXPOSE 8787
 
 CMD ["/usr/local/bin/start.sh"]
+
+ENV PATH $HOME/.local/bin:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -107,5 +107,3 @@ RUN chmod +x /usr/local/bin/start.sh
 EXPOSE 8787
 
 CMD ["/usr/local/bin/start.sh"]
-
-ENV PATH $HOME/.local/bin:$PATH

--- a/start.sh
+++ b/start.sh
@@ -103,7 +103,7 @@ sudo -i -u "${USER}" /usr/lib/rstudio-server/bin/rserver \
   --rsession-which-r="$RSTUDIO_ENV_PATH/bin/R"
 }
 
-sudo -i -u "${USER}" export PATH=$HOME/.local/bin:$PATH
+
 
 function main() {
   init_user

--- a/start.sh
+++ b/start.sh
@@ -103,7 +103,7 @@ sudo -i -u "${USER}" /usr/lib/rstudio-server/bin/rserver \
   --rsession-which-r="$RSTUDIO_ENV_PATH/bin/R"
 }
 
-export PATH=$HOME/.local/bin:$PATH
+sudo -i -u "${USER}" export PATH=$HOME/.local/bin:$PATH
 
 function main() {
   init_user

--- a/start.sh
+++ b/start.sh
@@ -102,6 +102,9 @@ sudo -i -u "${USER}" /usr/lib/rstudio-server/bin/rserver \
   --rsession-ld-library-path="/usr/lib/rstudio-server:/opt/conda/lib:$RSTUDIO_ENV_PATH/lib" \
   --rsession-which-r="$RSTUDIO_ENV_PATH/bin/R"
 }
+
+export PATH=$HOME/.local/bin:$PATH
+
 function main() {
   init_user
   init_conda


### PR DESCRIPTION
Remove adding .local/bin PATH in r-studio docker. Now we are specifying the full path to nbstripout on the pre-commit hook