### PR TITLE
Remove CircleCI v1 config

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,8 +1,0 @@
-version: 2
-jobs:
-  build:
-    docker:
-      - image: busybox
-    steps:
-      - checkout
-      - run: echo "tested"


### PR DESCRIPTION
v1 has been deprecated for over a year, we should remove our configuration