### PR TITLE
Disable authentication for rstudio

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -130,6 +130,10 @@ RUN echo "options(repos = c(CRAN=https://cran.rstudio.com), download.file.method
     && git config --system push.default simple \
     && update-alternatives --set editor /bin/nano
 
+# RStudio config to disable authentication
+# This will only get read as part of the '/init' script when/if we switch to the S6 overlay scripts
+RUN echo "auth-none=1" >> "/etc/rstudio/rserver.conf"
+
 EXPOSE 8787
 
 # Override the /init entrypoint and use our own start.sh script

--- a/TODO.md
+++ b/TODO.md
@@ -2,6 +2,6 @@
 
 This file tracks the list of long term wants and needs for the RStudio image
 
-- [ ] /etc/rstudio/rserver.conf needs auth-none=1 adding
+- [-] /etc/rstudio/rserver.conf needs auth-none=1 adding
 - [ ] Use the pre-packaged S6 overlay scripts from rocker
 - [ ] Revert back to using UID 1000 for the main user


### PR DESCRIPTION
This disables authentication for rstudio server when it is run as part
of the service script in /etc/init.d/rstudio-server and the start script
in /etc/cont-init.d/userconf