### PR TITLE
Only run Docker build in the private repository

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actionshub/markdownlint@master
 
   docker:
+    if: github.repository == 'analytics-platform-rstudio'
     runs-on: [self-hosted, ecr]
     env:
       REPOSITORY: rstudio

--- a/.github/workflows/sync-repo.yaml
+++ b/.github/workflows/sync-repo.yaml
@@ -8,6 +8,7 @@ on:
 jobs:
   repo-sync:
     name: Repo Sync
+    if: github.repository == 'analytics-platform-rstudio-public'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
The Docker build will always fail in the Public fork as it doesn't have
access to the self-hosted runners