### PR TITLE
Build from rocker image 4.4.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rocker/rstudio:4.2.3
+FROM rocker/rstudio:4.4.0
 LABEL maintainer=analytics-platform-tech@digital.justice.gov.uk
 
 COPY secure-cookie-key.sh /etc/cont-init.d/secure-cookie-key-conf


### PR DESCRIPTION
Build from rocker image 4.4.0 to use R version 4.4.0.
Details of the image can be found [here](https://github.com/rocker-org/rocker-versioned2/wiki/rstudio_08e7decc3629) 
Dockerfile for this image can be seen [here](https://github.com/rocker-org/rocker-versioned2/blob/master/dockerfiles/rstudio_4.4.0.Dockerfile)

Upgrade to R is needed to fix a [security vulnerability](https://kb.cert.org/vuls/id/238194?utm_source=customerio&utm_medium=email&utm_campaign=240508_1-r-datalab_2-mix_3-all_4-na_5-na_6-na_7-ws_8-emal-ci_9-na_10-bau_11-email&dc_euid=619371)

In the dev Control Panel I have created a release for this image, deployed the image, and confirmed that it is using R version 4.4.0.