### PR TITLE
Amend rocker Rstudio to 4.4.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rocker/rstudio:4.4.0
+FROM rocker/rstudio:4.4.1
 LABEL maintainer=analytics-platform-tech@digital.justice.gov.uk
 
 COPY secure-cookie-key.sh /etc/cont-init.d/secure-cookie-key-conf


### PR DESCRIPTION
As a result of this support [ticket ](https://github.com/ministryofjustice/data-platform-support/issues/701)

There is a need to upgrade rocker/rstudio:4.4.0 to rocker/rstudio:4.4.1 to fix the issue identified in the ticket 