### PR TITLE
Create default user from USER env var

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,3 +59,8 @@ RUN patch -u /etc/cont-init.d/02_userconf -i /userconf.patch
 RUN rm -f /etc/cont-init.d/02_userconf.orig
 
 RUN echo '\nulimit -S -c 0' >> /etc/profile
+
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,4 +63,4 @@ RUN echo '\nulimit -S -c 0' >> /etc/profile
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 
-ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+# ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,4 +63,4 @@ RUN echo '\nulimit -S -c 0' >> /etc/profile
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 
-# ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
     depends_on: [nginx-proxy]
     environment:
       SECURE_COOKIE_KEY: "8865825c306d4bd1a90c505dcde189fb" # gitleaks:allow
-      AWS_DEFAULT_REGION: "eu-north-1"
+      AWS_DEFAULT_REGION: "eu-west-1"
 
   inspec:
     image: chef/inspec:current

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,4 @@
 ---
-version: "3.9"
-
 services:
   test_files:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
     depends_on: [nginx-proxy]
     environment:
       SECURE_COOKIE_KEY: "8865825c306d4bd1a90c505dcde189fb" # gitleaks:allow
-      AWS_DEFAULT_REGION: "eu-west-1"
+      AWS_DEFAULT_REGION: "eu-north-1"
 
   inspec:
     image: chef/inspec:current

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,4 +20,9 @@ else
     exit 1
 fi
 
-exec "$@"
+if [ "$#" -eq 0 ]; then
+	echo "No command provided. Keeping the container running..."
+	tail -f /dev/null
+else
+	exec "$@"
+fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,14 +2,22 @@
 set -e
 
 # Use the USER environment variable passed in from Helm to set DEFAULT_USER
-export DEFAULT_USER="${USER:-rstudio}"
+USER_NAME="${USER:-rstudio}"
+export DEFAULT_USER="$USER_NAME"
 
 # Remove user with UID 1000 if it exists (the default user)
-if id -u 1000 &>/dev/null; then
+if id -u 1000 &>/dev/null && [ "$(id -un 1000)" != "$DEFAULT_USER" ]; then
+    echo "Removing default user with UID 1000"
 	userdel --remove "$(id -un 1000)"
 fi
 
-# Recreate the default user with correct username
-/rocker_scripts/default_user.sh
+if [ -x /rocker_scripts/default_user.sh ]; then
+	# Recreate the default user with correct username
+	echo "Running default_user.sh"
+	/rocker_scripts/default_user.sh
+else
+    echo "default_user.sh not found or not executable" >&2
+    exit 1
+fi
 
 exec "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,16 +6,16 @@ USER_NAME="${USER:-rstudio}"
 export DEFAULT_USER="$USER_NAME"
 
 if id -u 1000 &>/dev/null && [ "$(id -un 1000)" != "$DEFAULT_USER" ]; then
-    echo "Removing default user with UID 1000"
-    userdel --remove "$(id -un 1000)"
+	echo "Removing default user with UID 1000"
+	userdel --remove "$(id -un 1000)"
 fi
 
 if [ -x /rocker_scripts/default_user.sh ]; then
-    echo "Running default_user.sh"
-    /rocker_scripts/default_user.sh
+	echo "Running default_user.sh"
+	/rocker_scripts/default_user.sh
 else
-    echo "default_user.sh not found or not executable" >&2
-    exit 1
+	echo "default_user.sh not found or not executable" >&2
+	exit 1
 fi
 
 # Start s6 to run init scripts (including secure-cookie-key-conf)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,28 +1,22 @@
 #!/bin/bash
 set -e
 
-# Use the USER environment variable passed in from Helm to set DEFAULT_USER
+# Setup user (as you already have)
 USER_NAME="${USER:-rstudio}"
 export DEFAULT_USER="$USER_NAME"
 
-# Remove user with UID 1000 if it exists (the default user)
 if id -u 1000 &>/dev/null && [ "$(id -un 1000)" != "$DEFAULT_USER" ]; then
     echo "Removing default user with UID 1000"
-	userdel --remove "$(id -un 1000)"
+    userdel --remove "$(id -un 1000)"
 fi
 
 if [ -x /rocker_scripts/default_user.sh ]; then
-	# Recreate the default user with correct username
-	echo "Running default_user.sh"
-	/rocker_scripts/default_user.sh
+    echo "Running default_user.sh"
+    /rocker_scripts/default_user.sh
 else
     echo "default_user.sh not found or not executable" >&2
     exit 1
 fi
 
-if [ "$#" -eq 0 ]; then
-	echo "No command provided. Keeping the container running..."
-	tail -f /dev/null
-else
-	exec "$@"
-fi
+# Start s6 to run init scripts (including secure-cookie-key-conf)
+/init

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+# Use the USER environment variable passed in from Helm to set DEFAULT_USER
+export DEFAULT_USER="${USER:-rstudio}"
+
+# Remove user with UID 1000 if it exists (the default user)
+if id -u 1000 &>/dev/null; then
+	userdel --remove "$(id -un 1000)"
+fi
+
+# Recreate the default user with correct username
+/rocker_scripts/default_user.sh
+
+exec "$@"

--- a/tests/controls/environment_spec.rb
+++ b/tests/controls/environment_spec.rb
@@ -20,6 +20,6 @@ control "PATH variable" do
   end
 
   describe os_env("AWS_DEFAULT_REGION") do
-    its("content") { should eq "eu-west-1" }
+    its("content") { should eq "eu-north-1" }
   end
 end

--- a/tests/controls/environment_spec.rb
+++ b/tests/controls/environment_spec.rb
@@ -20,6 +20,6 @@ control "PATH variable" do
   end
 
   describe os_env("AWS_DEFAULT_REGION") do
-    its("content") { should eq "eu-north-1" }
+    its("content") { should eq "eu-west-1" }
   end
 end

--- a/tests/controls/pip_spec.rb
+++ b/tests/controls/pip_spec.rb
@@ -26,6 +26,7 @@ control "osmnx" do
   tag "pip"
 
   describe bash("
+    rm -rf /tmp/osmnx_venv &&
     python3 -m venv /tmp/osmnx_venv &&
     source /tmp/osmnx_venv/bin/activate &&
     pip install --upgrade pip &&


### PR DESCRIPTION
Behaviour for creating the default user changed in the latest image. Therefore this PR adds an entrypoint script to create the default user with the username that is passed in from the helm chart deployment.yaml as the `USER` env var.

Se below for more details:
https://github.com/rocker-org/rocker-versioned2/blob/b7509ce5417fc6dc7eee457677fd98ac72897f27/NEWS.md#changes-in-pre-built-images