### PR TITLE
Pin syft-version to try to resolve SBOM file size error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,7 @@ jobs:
           image: ghcr.io/${{ github.repository }}:${{ github.ref_name }}
           format: cyclonedx-json
           output-file: "sbom.cyclonedx.json"
+          syft-version: v1.19.1
 
       - name: Attest
         uses: actions/attest-build-provenance@ef244123eb79f2f7a7e75d99086184180e6d0018 # v1.4.4


### PR DESCRIPTION
Attempt to fix error on release https://github.com/ministryofjustice/analytics-platform-rstudio/actions/runs/19894935740/job/57022792521

See related issue regarding syft version https://github.com/actions/attest-sbom/issues/168