### PR TITLE
Set CRAN default value

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@
 FROM rocker/rstudio:4.5.2
 LABEL maintainer=analytics-platform-tech@digital.justice.gov.uk
 
+# set default CRAN
+ENV CRAN="https://p3m.dev/cran/__linux__/noble/latest"
+
 COPY secure-cookie-key.sh /etc/cont-init.d/secure-cookie-key-conf
 COPY default_user.patch /tmp/default_user.patch
 


### PR DESCRIPTION
Set default CRAN value, to override what is set in the base image we build from. In [previous releases such as 4.5.1](https://github.com/rocker-org/rocker-versioned2/blob/master/dockerfiles/rstudio_4.5.1.Dockerfile#L12), this was set to a specific version, which can be confusing to users.

Relates to bug ticket https://github.com/ministryofjustice/analytical-platform/issues/9428